### PR TITLE
Add 'slot' and 'template' tags.

### DIFF
--- a/src/Giraffe.ViewEngine/Engine.fs
+++ b/src/Giraffe.ViewEngine/Engine.fs
@@ -232,6 +232,10 @@ module HtmlElements =
     let menuitem   = voidTag "menuitem"
     let summary    = tag "summary"
 
+    // Web Components
+    let slot       = tag "slot"
+    let template   = tag "template"
+
     // Others
     let iframe    = tag "iframe"
 


### PR DESCRIPTION
It seems the ViewEngine was missing two tags for Web Components. Easy to workaround with custom tags, but would be nice to have in the ViewEngine.