### PR TITLE
Minor optimization for building document trees

### DIFF
--- a/src/Giraffe.ViewEngine/Engine.fs
+++ b/src/Giraffe.ViewEngine/Engine.fs
@@ -35,7 +35,7 @@ module HtmlElements =
         | KeyValue of string * string
         | Boolean  of string
 
-    type XmlElement   = string * XmlAttribute list    // Name * XML attributes
+    type XmlElement   = (struct(string * XmlAttribute list))    // Name * XML attributes
 
     type XmlNode =
         | ParentNode  of XmlElement * XmlNode list // An XML element which contains nested XML elements
@@ -554,7 +554,7 @@ module internal ViewBuilder =
 
     let rec internal buildNode (isHtml : bool) (sb : StringBuilder) (node : XmlNode) : unit =
 
-        let buildElement closingBracket (elemName, attributes : XmlAttribute list) =
+        let buildElement closingBracket struct(elemName, attributes : XmlAttribute list) =
             match attributes with
             | [] -> do sb += "<" += elemName +! closingBracket
             | _    ->
@@ -568,7 +568,7 @@ module internal ViewBuilder =
 
                 do sb +! closingBracket
 
-        let inline buildParentNode (elemName, attributes : XmlAttribute list) (nodes : XmlNode list) =
+        let inline buildParentNode struct(elemName, attributes : XmlAttribute list) (nodes : XmlNode list) =
             do buildElement ">" (elemName, attributes)
             for node in nodes do buildNode isHtml sb node
             do sb += "</" += elemName +! ">"

--- a/src/Giraffe.ViewEngine/Engine.fs
+++ b/src/Giraffe.ViewEngine/Engine.fs
@@ -35,7 +35,7 @@ module HtmlElements =
         | KeyValue of string * string
         | Boolean  of string
 
-    type XmlElement   = string * XmlAttribute[]    // Name * XML attributes
+    type XmlElement   = string * XmlAttribute list    // Name * XML attributes
 
     type XmlNode =
         | ParentNode  of XmlElement * XmlNode list // An XML element which contains nested XML elements
@@ -58,11 +58,11 @@ module HtmlElements =
     let tag (tagName    : string)
             (attributes : XmlAttribute list)
             (contents   : XmlNode list) =
-        ParentNode ((tagName, Array.ofList attributes), contents)
+        ParentNode ((tagName, attributes), contents)
 
     let voidTag (tagName    : string)
                 (attributes : XmlAttribute list) =
-        VoidElement (tagName, Array.ofList attributes)
+        VoidElement (tagName, attributes)
 
     /// <summary>
     ///
@@ -554,21 +554,21 @@ module internal ViewBuilder =
 
     let rec internal buildNode (isHtml : bool) (sb : StringBuilder) (node : XmlNode) : unit =
 
-        let buildElement closingBracket (elemName, attributes : XmlAttribute array) =
+        let buildElement closingBracket (elemName, attributes : XmlAttribute list) =
             match attributes with
-            | [||] -> do sb += "<" += elemName +! closingBracket
+            | [] -> do sb += "<" += elemName +! closingBracket
             | _    ->
                 do sb += "<" +! elemName
 
                 attributes
-                |> Array.iter (fun attr ->
+                |> List.iter (fun attr ->
                     match attr with
                     | KeyValue (k, v) -> do sb += " " += k += "=\"" += v +! "\""
                     | Boolean k       -> do sb += " " +! k)
 
                 do sb +! closingBracket
 
-        let inline buildParentNode (elemName, attributes : XmlAttribute array) (nodes : XmlNode list) =
+        let inline buildParentNode (elemName, attributes : XmlAttribute list) (nodes : XmlNode list) =
             do buildElement ">" (elemName, attributes)
             for node in nodes do buildNode isHtml sb node
             do sb += "</" += elemName +! ">"

--- a/tests/Giraffe.ViewEngine.Benchmarks/Giraffe.ViewEngine.Benchmarks.fsproj
+++ b/tests/Giraffe.ViewEngine.Benchmarks/Giraffe.ViewEngine.Benchmarks.fsproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Giraffe.ViewEngine.Benchmarks/Program.fs
+++ b/tests/Giraffe.ViewEngine.Benchmarks/Program.fs
@@ -68,6 +68,51 @@ type HtmlUtf8Benchmark() =
         ArrayPool<char>.Shared.Return(chars)
         stringBuilder.Clear()
 
+[<MemoryDiagnoser>]
+type HtmlBuildBenchmark() =
+
+    let doc() =
+        div [] [
+            div [ _class "top-bar" ]
+                [ div [ _class "top-bar-left" ]
+                    [ ul [ _class "dropdown menu"
+                           _data "dropdown-menu" "" ]
+                        [ li [ _class "menu-text" ]
+                            [ rawText "Site Title" ]
+                          li [ ]
+                            [ a [ _href "#" ]
+                                [ str """One <script>alert("hello world")</script>""" ]
+                              ul [ _class "menu vertical" ]
+                                [ li [ ]
+                                    [ a [ _href "#" ]
+                                        [ rawText "One" ] ]
+                                  li [ ]
+                                    [ a [ _href "#" ]
+                                        [ str "Two" ] ]
+                                  li [ ]
+                                    [ a [ _href "#" ]
+                                        [ rawText "Three" ] ] ] ]
+                          li [ ]
+                            [ a [ _href "#" ]
+                                [ str "Two" ] ]
+                          li [ ]
+                            [ a [ _href "#" ]
+                                [ str "Three" ] ] ] ]
+                  div [ _class "top-bar-right" ]
+                    [ ul [ _class "menu" ]
+                        [ li [ ]
+                            [ input [ _type "search"
+                                      _placeholder "Search" ] ]
+                          li [ ]
+                            [ button [ _type "button"
+                                       _class "button" ]
+                                [ rawText "Search" ] ] ] ] ]
+        ]
+
+    [<Benchmark( Baseline = true )>]
+    member this.Default() =
+        doc()
+
 [<EntryPoint>]
 let main args =
     let asm = typeof<HtmlUtf8Benchmark>.Assembly


### PR DESCRIPTION
Changes:
1. Added a benchmark for building the document tree.
2. Removed a redundant ToArray for attributes in XmlElement by changing the collection type from array to list. The public functions (e.g. tag, voidTag, div etc) expect a list anyways.
3. Made XmlElement a struct.

Not sure about the breaking changes policy for this package. Changing the type of XmlElement is technically a breaking change. However, if the user uses the functions provided by ViewEngine - the build will not break. The functions do not expose the details of how XmlElement is constructed.

Results:
Perf: -27% (0.594 us) execution time on building the test document
Memory:  -26% (1.26KB) memory allocations when building the test document

No changes to serialisation benchmark (HtmlUtf8Benchmark)

Benchmark on master (1):
|  Method |     Mean |     Error |    StdDev |   Median | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|----------:|----------:|---------:|------:|-------:|------:|------:|----------:|
| Default | 2.175 us | 0.0434 us | 0.1096 us | 2.132 us |  1.00 | 1.5602 |     - |     - |   4.78 KB |

Benchmark after removing ToArray (2):
|  Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| Default | 1.682 us | 0.0285 us | 0.0484 us |  1.00 | 1.3313 |     - |     - |   4.08 KB |

Benchmark after making XmlElement a struct (3):
|  Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| Default | 1.581 us | 0.0096 us | 0.0090 us |  1.00 | 1.1463 |     - |     - |   3.52 KB |