### PR TITLE
Adding sourcelink

### DIFF
--- a/src/Giraffe.ViewEngine/Giraffe.ViewEngine.fsproj
+++ b/src/Giraffe.ViewEngine/Giraffe.ViewEngine.fsproj
@@ -43,6 +43,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="StringBuilderPool.fs" />
     <Compile Include="Engine.fs" />
   </ItemGroup>


### PR DESCRIPTION
Quick fix for the enhancement described in https://github.com/giraffe-fsharp/Giraffe.ViewEngine/issues/16

#### Notes

I noticed Giraffe core is on `1.0.*`

Judging by the [release notes for 1.1.0](https://github.com/dotnet/sourcelink/releases/tag/1.1.1), there's not much that would be different for this basic usage.