### PR TITLE
Adding SourceLink

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,11 @@ jobs:
         run: dotnet test -c Release
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: |
+          latestTag=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.1)
+          runId=$GITHUB_RUN_ID
+          packageVersion="${latestTag//v}-build.${runId}"
+          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$packageVersion src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2

--- a/src/Giraffe.ViewEngine/Giraffe.ViewEngine.fsproj
+++ b/src/Giraffe.ViewEngine/Giraffe.ViewEngine.fsproj
@@ -43,6 +43,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="StringBuilderPool.fs" />
     <Compile Include="Engine.fs" />
   </ItemGroup>


### PR DESCRIPTION
Quick fix for the enhancement described in https://github.com/giraffe-fsharp/Giraffe.ViewEngine/issues/16

#### Notes

I noticed Giraffe core is on `1.0.*`

Judging by the [release notes for 1.1.0](https://github.com/dotnet/sourcelink/releases/tag/1.1.1), there's not much that would be different for this basic usage.